### PR TITLE
Adding the ability to use proxy servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
   - composer require satooshi/php-coveralls
 
 before_script:
-  - vendor/bin/phpunit --version
   - composer self-update
   - composer install --prefer-source --dev
   - docker run -p 9000:9000 -p 8123:8123 -d --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - composer require satooshi/php-coveralls
 
 before_script:
+  - phpunit --version
   - composer self-update
   - composer install --prefer-source --dev
   - docker run -p 9000:9000 -p 8123:8123 -d --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - composer require satooshi/php-coveralls
 
 before_script:
-  - phpunit --version
+  - vendor/bin/phpunit --version
   - composer self-update
   - composer install --prefer-source --dev
   - docker run -p 9000:9000 -p 8123:8123 -d --name some-clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server
@@ -24,7 +24,7 @@ before_script:
   - make && make install
   - cd ../../
 
-script: phpunit --coverage-clover ./tests/logs/clover.xml
+script: vendor/bin/phpunit --coverage-clover ./tests/logs/clover.xml
 
 after_script:
  - php vendor/bin/php-coveralls -v

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ $serverProvider = (new Tinderbox\Clickhouse\ServerProvider())->addServer($server
 $client = (new Tinderbox\Clickhouse\Client($serverProvider));
 ```
 
-To use server with tag, you should call ```usingServerFromGroup``` function before execute any query.
+To use server with tag, you should call ```usingServerWithTag``` function before execute any query.
 
 ```php
-$client->usingServerFromGroup('tag');
+$client->usingServerWithTag('tag');
 ```
 
 ## Select queries

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ $client->using('server-2')->select('select * from table');
 ## Proxy servers
 
 ```php
-$proxyServer = new Tinderbox\Clickhouse\Server('127.0.0.1', '9090', null, 'user', 'pass');
+$firstProxyServer = new Tinderbox\Clickhouse\Server('127.0.0.1', '9090', null, 'user', 'pass');
+$secondProxyServer = new Tinderbox\Clickhouse\Server('127.0.0.2', '9090', null, 'user', 'pass');
 
-$serverProvider = (new Tinderbox\Clickhouse\ServerProvider())->addProxyServer($proxyServer);
+$serverProvider = (new Tinderbox\Clickhouse\ServerProvider())->addProxyServer($firstProxyServer)->addProxyServer($secondProxyServer);
 
 $client = (new Tinderbox\Clickhouse\Client($serverProvider));
 ```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ By default client will use random server in given list of servers or in specifie
 $client->using('server-2')->select('select * from table');
 ```
 
+## Proxy servers
+
+```php
+$proxyServer = new Tinderbox\Clickhouse\Server('127.0.0.1', '9090', null, 'user', 'pass');
+
+$serverProvider = (new Tinderbox\Clickhouse\ServerProvider())->addProxyServer($proxyServer);
+
+$client = (new Tinderbox\Clickhouse\Client($serverProvider));
+```
+
+To use proxy server you should call ```usingProxyServer``` function before execute any query.
+
+```php
+$client->usingProxyServer();
+```
+
 ## Select queries
 
 Any SELECT query will return instance of `Result`. This class implements interfaces `\ArrayAccess`, `\Countable` и `\Iterator`,

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $serverProvider = (new Tinderbox\Clickhouse\ServerProvider())->addProxyServer($f
 $client = (new Tinderbox\Clickhouse\Client($serverProvider));
 ```
 
-To use proxy server you should call ```usingProxyServer``` function before execute any query.
+To use proxy server, you should call ```usingProxyServer``` function before execute any query.
 
 ```php
 $client->usingProxyServer();

--- a/README.md
+++ b/README.md
@@ -72,21 +72,27 @@ By default client will use random server in given list of servers or in specifie
 $client->using('server-2')->select('select * from table');
 ```
 
-## Proxy servers
+## Server tags
 
 ```php
-$firstProxyServer = new Tinderbox\Clickhouse\Server('127.0.0.1', '9090', null, 'user', 'pass');
-$secondProxyServer = new Tinderbox\Clickhouse\Server('127.0.0.2', '9090', null, 'user', 'pass');
+$firstServerOptionsWithTag = (new \Tinderbox\Clickhouse\Common\ServerOptions())->setTag('tag');
+$secondServerOptionsWithAnotherTag = (new \Tinderbox\Clickhouse\Common\ServerOptions())->setTag('another-tag');
 
-$serverProvider = (new Tinderbox\Clickhouse\ServerProvider())->addProxyServer($firstProxyServer)->addProxyServer($secondProxyServer);
+$server = new Tinderbox\Clickhouse\Server('127.0.0.1', '8123', 'default', 'user', 'pass', $firstServerOptionsWithTag);
+
+$cluster = new Tinderbox\Clickhouse\Cluster('cluster', [
+    new Tinderbox\Clickhouse\Server('127.0.0.2', '8123', 'default', 'user', 'pass', $secondServerOptionsWithAnotherTag)
+]);
+
+$serverProvider = (new Tinderbox\Clickhouse\ServerProvider())->addServer($server)->addCluster($cluster);
 
 $client = (new Tinderbox\Clickhouse\Client($serverProvider));
 ```
 
-To use proxy server, you should call ```usingProxyServer``` function before execute any query.
+To use server with tag, you should call ```usingServerFromGroup``` function before execute any query.
 
 ```php
-$client->usingProxyServer();
+$client->usingServerFromGroup('tag');
 ```
 
 ## Select queries

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   "require-dev": {
     "mockery/mockery": "^0.9.9",
     "phpunit/php-code-coverage": "^5.2",
-    "phpunit/phpunit": "~4.0||~5.0||~6.0"
+    "phpunit/phpunit": "~4.0||~5.0||~6.0||~7.0"
   },
   "scripts": {
     "test": "phpunit --coverage-text --colors=never"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   },
   "require": {
     "php": "~7.1",
-    "guzzlehttp/guzzle": "~6.0"
+    "guzzlehttp/guzzle": "~6.0",
+    "satooshi/php-coveralls": "^2.2"
   },
   "bin": [
     "bin/ccat_linux",

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
   ],
   "require-dev": {
     "mockery/mockery": "^0.9.9",
-    "phpunit/php-code-coverage": "^5.2",
-    "phpunit/phpunit": "~4.0||~5.0||~6.0||~7.0"
+    "phpunit/php-code-coverage": "^6.0",
+    "phpunit/phpunit": "~7.0"
   },
   "scripts": {
     "test": "phpunit --coverage-text --colors=never"

--- a/src/Client.php
+++ b/src/Client.php
@@ -150,7 +150,7 @@ class Client
     /**
      * Client will use server with tag as server for queries.
      *
-     * @var string $tag
+     * @var string
      *
      * @return $this
      */

--- a/src/Client.php
+++ b/src/Client.php
@@ -148,6 +148,20 @@ class Client
     }
 
     /**
+     * Client will use proxy server as server for queries.
+     *
+     * @return $this
+     */
+    public function usingProxyServer()
+    {
+        $this->serverHostname = function () {
+            return $this->serverProvider->getRandomProxyServer();
+        };
+        
+        return $this;
+    }
+
+    /**
      * Returns true if cluster selected.
      *
      * @return bool

--- a/src/Client.php
+++ b/src/Client.php
@@ -148,14 +148,20 @@ class Client
     }
 
     /**
-     * Client will use proxy server as server for queries.
+     * Client will use server with tag as server for queries.
+     *
+     * @var string $group
      *
      * @return $this
      */
-    public function usingProxyServer()
+    public function usingServerWithTag(string $tag)
     {
-        $this->serverHostname = function () {
-            return $this->serverProvider->getRandomProxyServer();
+        $this->serverHostname = function () use ($tag) {
+            if ($this->isOnCluster()) {
+                return $this->serverProvider->getRandomServerFromClusterByTag($this->getClusterName(), $tag);
+            } else {
+                return $this->serverProvider->getRandomServerWithTag($tag);
+            }
         };
 
         return $this;

--- a/src/Client.php
+++ b/src/Client.php
@@ -150,7 +150,7 @@ class Client
     /**
      * Client will use server with tag as server for queries.
      *
-     * @var string $group
+     * @var string $tag
      *
      * @return $this
      */

--- a/src/Client.php
+++ b/src/Client.php
@@ -157,7 +157,7 @@ class Client
         $this->serverHostname = function () {
             return $this->serverProvider->getRandomProxyServer();
         };
-        
+
         return $this;
     }
 

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -97,7 +97,7 @@ class Cluster
         $serverTags = $server->getOptions()->getTags();
 
         foreach ($serverTags as $serverTag) {
-            $this->serversByTags[$serverTag][$hostname] = $server;
+            $this->serversByTags[$serverTag][$hostname] = true;
         }
     }
 
@@ -145,29 +145,6 @@ class Cluster
         }
 
         return $this->servers[$hostname];
-    }
-
-    /**
-     * Returns server by specified hostname and specified tag.
-     *
-     * @param string $tag
-     * @param string $hostname
-     *
-     * @throws \Tinderbox\Clickhouse\Exceptions\ClusterException
-     *
-     * @return \Tinderbox\Clickhouse\Server
-     */
-    public function getServerByTag(string $tag, string $hostname): Server
-    {
-        if (!isset($this->serversByTags[$tag])) {
-            throw ClusterException::tagNotFound($tag);
-        }
-
-        if (!isset($this->serversByTags[$tag][$hostname])) {
-            throw ClusterException::serverNotFoundByTag($tag, $hostname);
-        }
-
-        return $this->serversByTags[$tag][$hostname];
     }
 
     /**

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -24,6 +24,13 @@ class Cluster
     protected $servers = [];
 
     /**
+     * Servers in cluster by tags.
+     *
+     * @var \Tinderbox\Clickhouse\Server[][]
+     */
+    protected $serversByTags = [];
+
+    /**
      * Cluster constructor.
      *
      * @param string $name
@@ -86,6 +93,12 @@ class Cluster
         }
 
         $this->servers[$hostname] = $server;
+
+        $serverTags = $server->getOptions()->getTags();
+
+        foreach ($serverTags as $serverTag) {
+            $this->serversByTags[$serverTag][$hostname] = $server;
+        }
     }
 
     /**
@@ -96,6 +109,24 @@ class Cluster
     public function getServers(): array
     {
         return $this->servers;
+    }
+
+    /**
+     * Returns servers in cluster by tag.
+     *
+     * @param string $tag
+     *
+     * @throws ClusterException
+     *
+     * @return \Tinderbox\Clickhouse\Server[]
+     */
+    public function getServersByTag(string $tag): array
+    {
+        if (!isset($this->serversByTags[$tag])) {
+            throw ClusterException::tagNotFound($tag);
+        }
+
+        return $this->serversByTags[$tag];
     }
 
     /**
@@ -114,6 +145,29 @@ class Cluster
         }
 
         return $this->servers[$hostname];
+    }
+
+    /**
+     * Returns server by specified hostname and specified tag.
+     *
+     * @param string $tag
+     * @param string $hostname
+     *
+     * @throws \Tinderbox\Clickhouse\Exceptions\ClusterException
+     *
+     * @return \Tinderbox\Clickhouse\Server
+     */
+    public function getServerByTag(string $tag, string $hostname): Server
+    {
+        if (!isset($this->serversByTags[$tag])) {
+            throw ClusterException::tagNotFound($tag);
+        }
+
+        if (!isset($this->serversByTags[$tag][$hostname])) {
+            throw ClusterException::serverNotFoundByTag($tag, $hostname);
+        }
+
+        return $this->serversByTags[$tag][$hostname];
     }
 
     /**

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -121,7 +121,7 @@ class Cluster
      *
      * @return string
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Common/File.php
+++ b/src/Common/File.php
@@ -8,7 +8,7 @@ use Tinderbox\Clickhouse\Interfaces\FileInterface;
 
 class File extends AbstractFile implements FileInterface
 {
-    public function open(bool $gzip = true) : StreamInterface
+    public function open(bool $gzip = true): StreamInterface
     {
         $handle = fopen($this->getSource(), 'r');
 

--- a/src/Common/FileFromString.php
+++ b/src/Common/FileFromString.php
@@ -8,7 +8,7 @@ use Tinderbox\Clickhouse\Interfaces\FileInterface;
 
 class FileFromString extends AbstractFile implements FileInterface
 {
-    public function open(bool $gzip = true) : StreamInterface
+    public function open(bool $gzip = true): StreamInterface
     {
         $handle = fopen('php://memory', 'r+');
         fwrite($handle, $this->source);

--- a/src/Common/MergedFiles.php
+++ b/src/Common/MergedFiles.php
@@ -14,7 +14,7 @@ class MergedFiles extends File implements FileInterface
         return __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'ccat_'.strtolower(PHP_OS);
     }
 
-    public function open(bool $gzip = true) : StreamInterface
+    public function open(bool $gzip = true): StreamInterface
     {
         $descriptorspec = [
             0 => ['pipe', 'r'],

--- a/src/Common/ServerOptions.php
+++ b/src/Common/ServerOptions.php
@@ -15,6 +15,13 @@ class ServerOptions
     protected $protocol = 'http';
 
     /**
+     * Tags.
+     *
+     * @var array
+     */
+    protected $tags = [];
+
+    /**
      * Sets protocol.
      *
      * @param string $protocol
@@ -36,5 +43,47 @@ class ServerOptions
     public function getProtocol(): string
     {
         return $this->protocol;
+    }
+
+    /**
+     * Set tags.
+     *
+     * @param array $tags
+     *
+     * @return ServerOptions
+     */
+    public function setTags(array $tags): self
+    {
+        $this->tags = [];
+
+        foreach ($tags as $tag) {
+            $this->addTag($tag);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adds tag.
+     *
+     * @param string $tag
+     *
+     * @return ServerOptions
+     */
+    public function addTag(string $tag): self
+    {
+        $this->tags[$tag] = true;
+
+        return $this;
+    }
+
+    /**
+     * Returns tags.
+     *
+     * @return array
+     */
+    public function getTags(): array
+    {
+        return array_keys($this->tags);
     }
 }

--- a/src/Common/TempTable.php
+++ b/src/Common/TempTable.php
@@ -94,7 +94,7 @@ class TempTable implements FileInterface
         return $this->format;
     }
 
-    public function open(bool $gzip = true) : StreamInterface
+    public function open(bool $gzip = true): StreamInterface
     {
         return $this->source->open($gzip);
     }

--- a/src/Exceptions/ClusterException.php
+++ b/src/Exceptions/ClusterException.php
@@ -21,4 +21,14 @@ class ClusterException extends \Exception
     {
         return new static('Server with hostname ['.$hostname.'] is not found in cluster');
     }
+
+    public static function tagNotFound($tag)
+    {
+        return new static('There are no servers with tag ['.$tag.'] in cluster');
+    }
+
+    public static function serverNotFoundByTag($tag, $hostname)
+    {
+        return new static('Server with hostname ['.$hostname.'] and tag ['.$tag.'] is not found in cluster');
+    }
 }

--- a/src/Exceptions/ServerProviderException.php
+++ b/src/Exceptions/ServerProviderException.php
@@ -26,4 +26,14 @@ class ServerProviderException extends \Exception
     {
         return new static('Can not find server with hostname ['.$hostname.']');
     }
+
+    public static function proxyServerHostnameDuplicate($hostname)
+    {
+        return new static('Proxy server with hostname ['.$hostname.'] already provided');
+    }
+
+    public static function proxyServerHostnameNotFound($hostname)
+    {
+        return new static('Can not find proxy server with hostname ['.$hostname.']');
+    }
 }

--- a/src/Exceptions/ServerProviderException.php
+++ b/src/Exceptions/ServerProviderException.php
@@ -27,13 +27,13 @@ class ServerProviderException extends \Exception
         return new static('Can not find server with hostname ['.$hostname.']');
     }
 
-    public static function proxyServerHostnameDuplicate($hostname)
+    public static function serverTagNotFound($tag)
     {
-        return new static('Proxy server with hostname ['.$hostname.'] already provided');
+        return new static('Can not find servers with tag ['.$tag.']');
     }
 
-    public static function proxyServerHostnameNotFound($hostname)
+    public static function serverHostnameNotFoundForTag($tag, $hostname)
     {
-        return new static('Can not find proxy server with hostname ['.$hostname.']');
+        return new static('Can not find servers with hostname ['.$hostname.'] and tag ['.$tag.']');
     }
 }

--- a/src/Interfaces/FileInterface.php
+++ b/src/Interfaces/FileInterface.php
@@ -6,5 +6,5 @@ use Psr\Http\Message\StreamInterface;
 
 interface FileInterface
 {
-    public function open(bool $gzip = true) : StreamInterface;
+    public function open(bool $gzip = true): StreamInterface;
 }

--- a/src/Query/QueryStatistic.php
+++ b/src/Query/QueryStatistic.php
@@ -14,7 +14,7 @@ use Tinderbox\Clickhouse\Exceptions\QueryStatisticException;
  * @property int   $rows
  * @property int   $bytes
  * @property float $time
- * @property int $rowsBeforeLimitAtLeast
+ * @property int   $rowsBeforeLimitAtLeast
  */
 class QueryStatistic
 {

--- a/src/Server.php
+++ b/src/Server.php
@@ -64,9 +64,9 @@ class Server
     public function __construct(
         string $host,
         string $port = '8123',
-        string $database = 'default',
-        string $username = null,
-        string $password = null,
+        ?string $database = 'default',
+        ?string $username = null,
+        ?string $password = null,
         ServerOptions $options = null
     ) {
         $this->setHost($host);

--- a/src/ServerProvider.php
+++ b/src/ServerProvider.php
@@ -24,6 +24,13 @@ class ServerProvider
     protected $servers = [];
 
     /**
+     * Proxy servers.
+     *
+     * @var Server[]
+     */
+    protected $proxyServers = [];
+
+    /**
      * Current server to perform queries.
      *
      * @var Server
@@ -63,6 +70,24 @@ class ServerProvider
         return $this;
     }
 
+    public function addProxyServer(Server $server)
+    {
+        $serverHostname = $server->getHost();
+
+        if (isset($this->proxyServers[$serverHostname])) {
+            throw ServerProviderException::serverHostnameDuplicate($serverHostname);
+        }
+
+        $this->proxyServers[$serverHostname] = $server;
+
+        return $this;
+    }
+
+    public function getRandomProxyServer(): Server
+    {
+        return $this->getProxyServer(array_rand($this->proxyServers, 1));
+    }
+
     public function getRandomServer(): Server
     {
         return $this->getServer(array_rand($this->servers, 1));
@@ -90,6 +115,17 @@ class ServerProvider
         }
 
         return $this->servers[$serverHostname];
+    }
+
+    public function getProxyServer(string $serverHostname): Server
+    {
+        if (!isset($this->proxyServers[$serverHostname])) {
+            throw ServerProviderException::serverHostnameNotFound($serverHostname);
+        }
+
+        $proxyServer = $this->proxyServers[$serverHostname];
+
+        return $proxyServer;
     }
 
     public function getCluster(string $cluster) : Cluster

--- a/src/ServerProvider.php
+++ b/src/ServerProvider.php
@@ -75,7 +75,7 @@ class ServerProvider
         $serverHostname = $server->getHost();
 
         if (isset($this->proxyServers[$serverHostname])) {
-            throw ServerProviderException::serverHostnameDuplicate($serverHostname);
+            throw ServerProviderException::proxyServerHostnameDuplicate($serverHostname);
         }
 
         $this->proxyServers[$serverHostname] = $server;
@@ -120,7 +120,7 @@ class ServerProvider
     public function getProxyServer(string $serverHostname): Server
     {
         if (!isset($this->proxyServers[$serverHostname])) {
-            throw ServerProviderException::serverHostnameNotFound($serverHostname);
+            throw ServerProviderException::proxyServerHostnameNotFound($serverHostname);
         }
 
         $proxyServer = $this->proxyServers[$serverHostname];

--- a/src/ServerProvider.php
+++ b/src/ServerProvider.php
@@ -93,18 +93,18 @@ class ServerProvider
     public function getRandomServerFromCluster(string $cluster): Server
     {
         $cluster = $this->getCluster($cluster);
-        $randomServerIndex = array_rand($cluster->getServers(), 1);
+        $randomServerHostname = array_rand($cluster->getServers(), 1);
 
-        return $cluster->getServerByHostname($randomServerIndex);
+        return $cluster->getServerByHostname($randomServerHostname);
     }
 
     public function getRandomServerFromClusterByTag(string $cluster, string $tag): Server
     {
         $cluster = $this->getCluster($cluster);
 
-        $randomServerIndex = array_rand($cluster->getServersByTag($tag), 1);
+        $randomServerHostname = array_rand($cluster->getServersByTag($tag), 1);
 
-        return $cluster->getServerByHostname($randomServerIndex);
+        return $cluster->getServerByHostname($randomServerHostname);
     }
 
     public function getServerFromCluster(string $cluster, string $serverHostname)

--- a/src/ServerProvider.php
+++ b/src/ServerProvider.php
@@ -128,7 +128,7 @@ class ServerProvider
         return $proxyServer;
     }
 
-    public function getCluster(string $cluster) : Cluster
+    public function getCluster(string $cluster): Cluster
     {
         if (!isset($this->clusters[$cluster])) {
             throw ServerProviderException::clusterNotFound($cluster);

--- a/src/ServerProvider.php
+++ b/src/ServerProvider.php
@@ -70,7 +70,7 @@ class ServerProvider
         $serverTags = $server->getOptions()->getTags();
 
         foreach ($serverTags as $serverTag) {
-            $this->serversByTags[$serverTag][$serverHostname] = $server;
+            $this->serversByTags[$serverTag][$serverHostname] = true;
         }
 
         return $this;
@@ -87,7 +87,7 @@ class ServerProvider
             throw ServerProviderException::serverTagNotFound($tag);
         }
 
-        return $this->getServerWithTag($tag, array_rand($this->serversByTags[$tag], 1));
+        return $this->getServer(array_rand($this->serversByTags[$tag], 1));
     }
 
     public function getRandomServerFromCluster(string $cluster): Server
@@ -104,7 +104,7 @@ class ServerProvider
 
         $randomServerIndex = array_rand($cluster->getServersByTag($tag), 1);
 
-        return $cluster->getServerByTag($tag, $randomServerIndex);
+        return $cluster->getServerByHostname($randomServerIndex);
     }
 
     public function getServerFromCluster(string $cluster, string $serverHostname)
@@ -121,19 +121,6 @@ class ServerProvider
         }
 
         return $this->servers[$serverHostname];
-    }
-
-    public function getServerWithTag(string $tag, string $serverHostname): Server
-    {
-        if (!isset($this->serversByTags[$tag])) {
-            throw ServerProviderException::serverTagNotFound($tag);
-        }
-
-        if (!isset($this->serversByTags[$tag][$serverHostname])) {
-            throw ServerProviderException::serverHostnameNotFoundForTag($tag, $serverHostname);
-        }
-
-        return $this->serversByTags[$tag][$serverHostname];
     }
 
     public function getCluster(string $cluster): Cluster

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -62,7 +62,7 @@ class HttpTransport implements TransportInterface
     }
 
     /**
-     * Returns flag to enable / disable queries and data compression
+     * Returns flag to enable / disable queries and data compression.
      *
      * @return bool
      */
@@ -121,7 +121,7 @@ class HttpTransport implements TransportInterface
      *
      * @return array
      */
-    public function write(array $queries, int $concurrency = 5) : array
+    public function write(array $queries, int $concurrency = 5): array
     {
         $result = [];
         $openedStreams = [];
@@ -159,9 +159,11 @@ class HttpTransport implements TransportInterface
             $queryResult = [];
 
             $pool = new Pool(
-                $this->httpClient, $requests($query), [
+                $this->httpClient,
+                $requests($query),
+                [
                     'concurrency' => $concurrency,
-                    'fulfilled'   => function ($response, $index) use (&$queryResult, $query) {
+                    'fulfilled'   => function ($response, $index) use (&$queryResult) {
                         $queryResult[$index] = true;
                     },
                     'rejected' => $this->parseReason($query),
@@ -195,7 +197,7 @@ class HttpTransport implements TransportInterface
         return $result;
     }
 
-    public function read(array $queries, int $concurrency = 5) : array
+    public function read(array $queries, int $concurrency = 5): array
     {
         $openedStreams = [];
 
@@ -241,7 +243,9 @@ class HttpTransport implements TransportInterface
         $result = [];
 
         $pool = new Pool(
-            $this->httpClient, $requests($queries), [
+            $this->httpClient,
+            $requests($queries),
+            [
                 'concurrency' => $concurrency,
                 'fulfilled'   => function ($response, $index) use (&$result, $queries) {
                     $result[$index] = $this->assembleResult($queries[$index], $response);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -174,6 +174,33 @@ class ClientTest extends TestCase
         $this->assertEquals(8123, $server->getPort());
     }
 
+    public function testServersWithTagsOnCluster()
+    {
+        $serverOptionsWithTag = (new ServerOptions())->addTag('tag');
+
+        $serverWithTag = (new Server('127.0.0.1', 8123))->setOptions($serverOptionsWithTag);
+        $serverWithoutTag = new Server('127.0.0.2', 8123);
+
+        $cluster = new Cluster(
+            'test',
+            [
+                $serverWithTag,
+                $serverWithoutTag,
+            ]
+        );
+
+        $serverProvider = new ServerProvider();
+        $serverProvider->addCluster($cluster);
+
+        $client = new Client($serverProvider);
+        $client->onCluster('test')->usingServerWithTag('tag');
+
+        $server = $client->getServer();
+
+        $this->assertEquals('127.0.0.1', $server->getHost());
+        $this->assertEquals(8123, $server->getPort());
+    }
+
     public function testClusterAndServersTogether()
     {
         $cluster = new Cluster(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -152,6 +152,23 @@ class ClientTest extends TestCase
         $client->using('127.0.0.0')->getServer();
     }
 
+    public function testProxies()
+    {
+        $server1 = new Server('127.0.0.1', 8123);
+        $proxy = new Server('127.0.0.2', 9090);
+
+        $serverProvider = new ServerProvider();
+        $serverProvider->addServer($server1)->addProxyServer($proxy);
+
+        $client = new Client($serverProvider);
+        $client->usingProxyServer();
+
+        $server = $client->getServer();
+
+        $this->assertEquals('127.0.0.2', $server->getHost());
+        $this->assertEquals(9090, $server->getPort());
+    }
+
     public function testClusterAndServersTogether()
     {
         $cluster = new Cluster(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -55,7 +55,8 @@ class ClientTest extends TestCase
     public function testClusters()
     {
         $cluster = new Cluster(
-            'test', [
+            'test',
+            [
                 new Server('127.0.0.1'),
                 new Server('127.0.0.2'),
                 new Server('127.0.0.3'),
@@ -63,7 +64,8 @@ class ClientTest extends TestCase
         );
 
         $cluster2 = new Cluster(
-            'test2', [
+            'test2',
+            [
                 new Server('127.0.0.4'),
                 new Server('127.0.0.5'),
                 new Server('127.0.0.6'),
@@ -172,7 +174,8 @@ class ClientTest extends TestCase
     public function testClusterAndServersTogether()
     {
         $cluster = new Cluster(
-            'test', [
+            'test',
+            [
                 new Server('127.0.0.1'),
                 new Server('127.0.0.2'),
                 new Server('127.0.0.3'),

--- a/tests/ClusterTest.php
+++ b/tests/ClusterTest.php
@@ -111,6 +111,15 @@ class ClusterTest extends TestCase
         $this->assertEquals($server['username'], $createdServer->getUsername());
         $this->assertEquals($server['password'], $createdServer->getPassword());
         $this->assertEquals($server['options'], $createdServer->getOptions());
+
+        $createdServer = $cluster->getServersByTag('tag');
+
+        $this->assertEquals($server['host'], $createdServer->getHost());
+        $this->assertEquals($server['port'], $createdServer->getPort());
+        $this->assertEquals($server['database'], $createdServer->getDatabase());
+        $this->assertEquals($server['username'], $createdServer->getUsername());
+        $this->assertEquals($server['password'], $createdServer->getPassword());
+        $this->assertEquals($server['options'], $createdServer->getOptions());
     }
 
     public function testServerTagNotFound()

--- a/tests/ClusterTest.php
+++ b/tests/ClusterTest.php
@@ -103,18 +103,9 @@ class ClusterTest extends TestCase
             $server,
         ]);
 
-        $createdServer = $cluster->getServerByTag('tag', '127.0.0.1');
-
-        $this->assertEquals($server['host'], $createdServer->getHost());
-        $this->assertEquals($server['port'], $createdServer->getPort());
-        $this->assertEquals($server['database'], $createdServer->getDatabase());
-        $this->assertEquals($server['username'], $createdServer->getUsername());
-        $this->assertEquals($server['password'], $createdServer->getPassword());
-        $this->assertEquals($server['options'], $createdServer->getOptions());
-
         $servers = $cluster->getServersByTag('tag');
 
-        $this->assertEquals(['127.0.0.1' => $createdServer], $servers);
+        $this->assertEquals(array_keys($servers)[0], $server['host']);
     }
 
     public function testServerTagNotFound()
@@ -125,45 +116,5 @@ class ClusterTest extends TestCase
         $this->expectExceptionMessage('There are no servers with tag [tag] in cluster');
 
         $cluster->getServersByTag('tag');
-    }
-
-    public function testServerTagNotFoundWhileGettingServer()
-    {
-        $cluster = new Cluster('test', []);
-
-        $this->expectException(ClusterException::class);
-        $this->expectExceptionMessage('There are no servers with tag [tag] in cluster');
-
-        $cluster->getServerByTag('tag', '127.0.0.1');
-    }
-
-    public function testServerNotFoundByTag()
-    {
-        $serverWithTag = [
-            'host'     => '127.0.0.1',
-            'port'     => 8123,
-            'database' => 'default',
-            'username' => 'default',
-            'password' => '',
-            'options'  => (new ServerOptions())->addTag('tag'),
-        ];
-
-        $serverWithoutTag = [
-            'host'     => '127.0.0.2',
-            'port'     => 8123,
-            'database' => 'default',
-            'username' => 'default',
-            'password' => '',
-        ];
-
-        $cluster = new Cluster('test', [
-            $serverWithTag,
-            $serverWithoutTag,
-        ]);
-
-        $this->expectException(ClusterException::class);
-        $this->expectExceptionMessage('Server with hostname [127.0.0.2] and tag [tag] is not found in cluster');
-
-        $cluster->getServerByTag('tag', '127.0.0.2');
     }
 }

--- a/tests/ClusterTest.php
+++ b/tests/ClusterTest.php
@@ -145,7 +145,7 @@ class ClusterTest extends TestCase
 
         $cluster = new Cluster('test', [
             $serverWithTag,
-            $serverWithoutTag
+            $serverWithoutTag,
         ]);
 
         $this->expectException(ClusterException::class);

--- a/tests/ClusterTest.php
+++ b/tests/ClusterTest.php
@@ -125,6 +125,15 @@ class ClusterTest extends TestCase
         $this->expectExceptionMessage('There are no servers with tag [tag] in cluster');
 
         $cluster->getServersByTag('tag');
+    }
+
+    public function testServerTagNotFoundWhileGettingServer()
+    {
+        $cluster = new Cluster('test', []);
+
+        $this->expectException(ClusterException::class);
+        $this->expectExceptionMessage('There are no servers with tag [tag] in cluster');
+
         $cluster->getServerByTag('tag', '127.0.0.1');
     }
 

--- a/tests/ClusterTest.php
+++ b/tests/ClusterTest.php
@@ -112,14 +112,9 @@ class ClusterTest extends TestCase
         $this->assertEquals($server['password'], $createdServer->getPassword());
         $this->assertEquals($server['options'], $createdServer->getOptions());
 
-        $createdServer = $cluster->getServersByTag('tag');
+        $servers = $cluster->getServersByTag('tag');
 
-        $this->assertEquals($server['host'], $createdServer->getHost());
-        $this->assertEquals($server['port'], $createdServer->getPort());
-        $this->assertEquals($server['database'], $createdServer->getDatabase());
-        $this->assertEquals($server['username'], $createdServer->getUsername());
-        $this->assertEquals($server['password'], $createdServer->getPassword());
-        $this->assertEquals($server['options'], $createdServer->getOptions());
+        $this->assertEquals(['127.0.0.1' => $createdServer], $servers);
     }
 
     public function testServerTagNotFound()

--- a/tests/HttpTransportTest.php
+++ b/tests/HttpTransportTest.php
@@ -19,7 +19,7 @@ use Tinderbox\Clickhouse\Transport\HttpTransport;
  */
 class HttpTransportTest extends TestCase
 {
-    protected function getMockedTransport(array $responses) : HttpTransport
+    protected function getMockedTransport(array $responses): HttpTransport
     {
         $mock = new MockHandler($responses);
 
@@ -30,17 +30,17 @@ class HttpTransportTest extends TestCase
         ]));
     }
 
-    protected function getQuery() : Query
+    protected function getQuery(): Query
     {
         return new Query($this->getServer(), 'select * from table');
     }
 
-    protected function getServer() : Server
+    protected function getServer(): Server
     {
         return new Server(CLICKHOUSE_SERVER_HOST, CLICKHOUSE_SERVER_PORT, 'default', 'default');
     }
 
-    protected function getTransport() : HttpTransport
+    protected function getTransport(): HttpTransport
     {
         return new HttpTransport();
     }

--- a/tests/HttpTransportTest.php
+++ b/tests/HttpTransportTest.php
@@ -377,7 +377,7 @@ class HttpTransportTest extends TestCase
         $transport = $this->getTransport();
 
         $this->expectException(TransportException::class);
-        $this->expectExceptionMessageRegExp('/Wrong password for user default/');
+        $this->expectExceptionMessageRegExp('/Authentication failed: password is incorrect/');
 
         $transport->read([
             new Query(new Server('127.0.0.1', 8123, 'default', 'default', 'pass'), 'select 1', [
@@ -391,7 +391,7 @@ class HttpTransportTest extends TestCase
         $transport = $this->getTransport();
 
         $this->expectException(TransportException::class);
-        $this->expectExceptionMessageRegExp('/Wrong password for user default/');
+        $this->expectExceptionMessageRegExp('/Authentication failed: password is incorrect/');
 
         $transport->write([
             new Query(new Server('127.0.0.1', 8123, 'default', 'default', 'pass'), 'insert into table 1', [

--- a/tests/ServerOptionsTest.php
+++ b/tests/ServerOptionsTest.php
@@ -10,7 +10,7 @@ use Tinderbox\Clickhouse\Common\ServerOptions;
  */
 class ServerOptionsTest extends TestCase
 {
-    public function testServerOptions()
+    public function testProtocolFromServerOptions()
     {
         $options = new ServerOptions();
 
@@ -19,5 +19,46 @@ class ServerOptionsTest extends TestCase
         $options->setProtocol('https');
 
         $this->assertEquals('https', $options->getProtocol(), 'Sets correct protocol');
+    }
+
+    public function testTagsFromServerOptions()
+    {
+        $options = new ServerOptions();
+
+        $options->addTag('test');
+
+        $this->assertTrue(
+            in_array('test', $options->getTags(), true),
+            'Sets correct tags'
+        );
+
+        $options->addTag('tag');
+
+        $this->assertTrue(
+            in_array('test', $options->getTags(), true),
+            'Sets correct tags'
+        );
+        $this->assertTrue(
+            in_array('tag', $options->getTags(), true),
+            'Sets correct tags'
+        );
+
+        $options->setTags(['other']);
+
+        $this->assertTrue(
+            in_array('other', $options->getTags(), true),
+            'Sets correct tags'
+        );
+
+        $options->addTag('tag');
+
+        $this->assertTrue(
+            in_array('other', $options->getTags(), true),
+            'Sets correct tags'
+        );
+        $this->assertTrue(
+            in_array('tag', $options->getTags(), true),
+            'Sets correct tags'
+        );
     }
 }

--- a/tests/ServerProviderTest.php
+++ b/tests/ServerProviderTest.php
@@ -133,6 +133,7 @@ class ServerProviderTest extends TestCase
         $this->expectExceptionMessage('Can not find servers with tag [tag]');
 
         $provider->getServerWithTag('tag', '127.0.0.1');
+        $provider->getRandomServerWithTag('tag');
     }
 
     public function testServerWithTagNotFound()

--- a/tests/ServerProviderTest.php
+++ b/tests/ServerProviderTest.php
@@ -135,32 +135,6 @@ class ServerProviderTest extends TestCase
         $provider->getRandomServerWithTag('tag');
     }
 
-    public function testServerTagNotFoundWhileGettingServer()
-    {
-        $provider = new ServerProvider();
-
-        $this->expectException(ServerProviderException::class);
-        $this->expectExceptionMessage('Can not find servers with tag [tag]');
-
-        $provider->getServerWithTag('tag', '127.0.0.1');
-    }
-
-    public function testServerWithTagNotFound()
-    {
-        $serverOptionsWithTag = (new ServerOptions())->addTag('tag');
-        $serverWithTag = new Server('127.0.0.1', 8123, 'default', 'default', '', $serverOptionsWithTag);
-        $serverWithoutTag = new Server('127.0.0.2', 8123);
-
-        $provider = new ServerProvider();
-        $provider->addServer($serverWithTag);
-        $provider->addServer($serverWithoutTag);
-
-        $this->expectException(ServerProviderException::class);
-        $this->expectExceptionMessage('Can not find servers with hostname [127.0.0.2] and tag [tag]');
-
-        $provider->getServerWithTag('tag', '127.0.0.2');
-    }
-
     public function testClustersWithServersWithTag()
     {
         $serverOptionsWithTag = (new ServerOptions())->addTag('tag');

--- a/tests/ServerProviderTest.php
+++ b/tests/ServerProviderTest.php
@@ -107,4 +107,47 @@ class ServerProviderTest extends TestCase
 
         $provider->getServer('127.0.0.1');
     }
+
+    public function testProxyServers()
+    {
+        $proxyServers = [
+            new Server('127.0.0.1', 9090),
+            new Server('127.0.0.2', 9090),
+        ];
+
+        $provider = new ServerProvider();
+        $provider->addProxyServer($proxyServers[0]);
+        $provider->addProxyServer($proxyServers[1]);
+
+        $this->assertEquals($proxyServers[0], $provider->getProxyServer('127.0.0.1'), 'Correctly adds proxy server and returns it by hostname');
+
+        $server = $provider->getRandomProxyServer();
+        $this->assertTrue(
+            in_array($server->getHost(), ['127.0.0.1', '127.0.0.2'], true),
+            'Correctly adds proxy server and returns it by hostname'
+        );
+    }
+
+    public function testProxyServerDuplicate()
+    {
+        $server = new Server('127.0.0.1');
+
+        $provider = new ServerProvider();
+        $provider->addProxyServer($server);
+
+        $this->expectException(ServerProviderException::class);
+        $this->expectExceptionMessage('Proxy server with hostname [127.0.0.1] already provided');
+
+        $provider->addProxyServer($server);
+    }
+
+    public function testProxyServerNotFound()
+    {
+        $provider = new ServerProvider();
+
+        $this->expectException(ServerProviderException::class);
+        $this->expectExceptionMessage('Can not find proxy server with hostname [127.0.0.1]');
+
+        $provider->getProxyServer('127.0.0.1');
+    }
 }

--- a/tests/ServerProviderTest.php
+++ b/tests/ServerProviderTest.php
@@ -132,8 +132,17 @@ class ServerProviderTest extends TestCase
         $this->expectException(ServerProviderException::class);
         $this->expectExceptionMessage('Can not find servers with tag [tag]');
 
-        $provider->getServerWithTag('tag', '127.0.0.1');
         $provider->getRandomServerWithTag('tag');
+    }
+
+    public function testServerTagNotFoundWhileGettingServer()
+    {
+        $provider = new ServerProvider();
+
+        $this->expectException(ServerProviderException::class);
+        $this->expectExceptionMessage('Can not find servers with tag [tag]');
+
+        $provider->getServerWithTag('tag', '127.0.0.1');
     }
 
     public function testServerWithTagNotFound()


### PR DESCRIPTION
This PR adds the ability to add proxy servers (i.e. chproxy servers) and use them for queries by calling usingProxyServer function. This function chooses random proxy server from proxy servers in server provider.
Proxy servers may be added in server provider by addProxyServer function.